### PR TITLE
fix: resolve $ref and strip $defs/definitions/ref from tool schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,42 +1,6 @@
-# API keys and secrets
-.env
-.env~
-
-# gemini-cli settings
-.gemini/
-!gemini/config.yaml
-
-# Dependency directory
-node_modules
-bower_components
-
-# Editors
-.idea
-*.iml
-
-# OS metadata
+node_modules/
+dist/*.map
+src/*.map
 .DS_Store
-Thumbs.db
-
-# TypeScript build info files
-*.tsbuildinfo
-
-# Ignore built ts files
-dist
-
-# Docker folder to help skip auth refreshes
-.docker
-
-bundle
-
-# Test report files
-junit.xml
-packages/*/coverage/
-
-# Generated files
-packages/cli/src/generated/
-.integration-tests/
-.aider*
-
-# by @Intelligent-Internet
-.history
+*.log
+.env

--- a/README.md
+++ b/README.md
@@ -1,366 +1,144 @@
-# Gemini CLI - MCP/OpenAI Bridge Server
+# Gemini CLI Bridge
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen)](https://nodejs.org/)
-[![npm version](https://img.shields.io/npm/v/@intelligentinternet/gemini-cli-mcp-openai-bridge)](https://www.npmjs.com/package/@intelligentinternet/gemini-cli-mcp-openai-bridge)
 
-[中文文档](https://github.com/Intelligent-Internet/gemini-cli-common-bridge/blob/main/README.zh.md)
+OpenAI-compatible API bridge for Google's Gemini CLI. Lets any OpenAI-compatible client (OpenCode, Open WebUI, Cursor, etc.) use Gemini models — including the full CodeAssist API with Google OAuth.
 
-> **🎉 Built on Open Source Gemini CLI - Thanks to Google!**  
-> This project is built upon the open-source [Gemini CLI](https://github.com/google-gemini/gemini-cli) by Google. We appreciate Google's commitment to open source and their contribution to the developer community.
+**Built on** [@Intelligent-Internet/gemini-cli-mcp-openai-bridge](https://github.com/Intelligent-Internet/gemini-cli-mcp-openai-bridge) and the [Gemini CLI](https://github.com/google-gemini/gemini-cli).
 
-`@intelligentinternet/gemini-cli-mcp-openai-bridge` (or `gemini-cli-bridge`) is a versatile server application designed as a powerful extension to the `gemini-cli` ecosystem. It serves two primary roles:
+---
 
-1. **MCP Toolkit**: Exposes all built-in tools from `gemini-cli` (such as file system operations, web search powered by Gemini models, and web content understanding) through a unified MCP endpoint.
-   - Can also connect to any number of external MCP servers (only allowed in YOLO mode or when specific tools are configured in `configured` mode).
+## What This Fork Fixes
 
-2. **OpenAI-Compatible API Bridge**: Provides a fully compatible endpoint with the OpenAI Chat Completions API (`/v1/chat/completions`). This enables any third-party tool or application that supports the OpenAI API (such as [Open WebUI](https://github.com/open-webui/open-webui)) to seamlessly interact with the underlying Gemini models of `gemini-cli`.
+The upstream bridge had a bug where tool schemas containing `$ref`/`$defs` (used by AI coding agents like OpenCode) were rejected by the Gemini CodeAssist API with:
 
-## Features
+```
+Schema.ref 'QuestionPrompt' was set alongside unsupported fields.
+```
 
-- **Built on `gemini-cli`**: Directly built upon the core functionality of `gemini-cli`, ensuring deep integration with Gemini models.
-- **Native `gemini-cli` Tools**: Exposes `gemini-cli`'s built-in tools through the MCP protocol.
-- **External MCP Tool Aggregation**: Acts as an MCP hub, connecting and proxying tools from other tool servers (only in `yolo` mode or when specific tools are configured in `restricted` mode).
-- **Full OpenAI API Compatibility**: Provides `/v1/chat/completions` and `/v1/models` endpoints with support for both streaming and non-streaming requests.
-- **Flexible Model Configuration**: Allows configuring separate default LLM models for tool execution (such as web search summarization).
-- **Inherited Configuration & Authentication**: Automatically uses the same settings and authentication state as the main `gemini-cli` tool, requiring no duplicate configuration.
-- **Configurable Security Policies**: Implements MCP tool-based security model with `read-only`, `edit`, `configured`, and `yolo` modes to control tool execution.
+**Root cause:** `sanitizeGeminiSchema()` stripped `$ref` but left `$defs`/`definitions` intact and never resolved `$ref` references inline. The Gemini API rejects schemas containing these JSON Schema keywords.
 
-## Prerequisites
+**Fixes applied:**
+- Added `resolveRef()` to inline `$ref`/`ref` references from `$defs`/`definitions` before sanitization
+- Added `ref`, `$defs`, `definitions` to the unsupported keys list
+- Added `this.config.setModel()` so model selection in clients actually switches the Gemini model
+- Added Geminie 3.x models (`gemini-3-flash-preview`, `gemini-3-pro-preview`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite`)
+- Handles both JSON Schema `$ref` and Google protobuf `ref` formats
 
-- [Node.js](https://nodejs.org/) v18 or higher
-- All dependencies and configuration required by [Gemini CLI](https://github.com/google-gemini/gemini-cli)
-  - This project automatically installs `gemini-cli` as a submodule (from the official `gemini-cli` GitHub repository), so you don't need to install it separately.
-  - If you already have `gemini-cli` installed, it will be overridden by this project's submodule version.
+---
 
-## Installation
+## Quick Start
 
 ```bash
 npm install -g @intelligentinternet/gemini-cli-mcp-openai-bridge
+
+# Start with edit mode (allows file writing)
+gemini-cli-bridge --mode edit --port 9000
 ```
 
-## Usage
+Bridge starts at `http://127.0.0.1:9000/v1` — works with any OpenAI-compatible client.
 
-**Security Warning**: This bridge server **does not ask for user confirmation** when invoking tools.
-- For your safety, the MCP bridge service defaults to `read-only` mode and will not bridge other MCP services you have configured in settings.json.
-- This project does not provide a runtime sandbox. If you wish to configure a `YOLO` security policy, please ensure your environment cannot be damaged by accidentally executed shell commands (strongly recommended to run in a container).
+---
 
-### 1. Start the Server
+## Models
 
-Run the command in your terminal. You can use command-line arguments to override default settings.
+The bridge exposes these models via `/v1/models`:
 
-```bash
-# Start server on all network interfaces at port 9000 with debug mode enabled
-gemini-cli-bridge --host=127.0.0.1 --port=9000 --debug
+| Model ID | Gemini API Model |
+|---|---|
+| `gemini-3.1-pro-preview` | Gemini 3.1 Pro |
+| `gemini-3.1-flash-lite` | Gemini 3.1 Flash Lite |
+| `gemini-3-pro-preview` | Gemini 3 Pro |
+| `gemini-3-flash-preview` | Gemini 3 Flash |
+| `gemini-2.5-pro` | Gemini 2.5 Pro |
+| `gemini-2.5-flash` | Gemini 2.5 Flash |
 
-# Use a faster model for tool calls and load internal GEMINI.md prompts
-gemini-cli-bridge --tools-model=gemini-2.5-flash --use-internal-prompt
-```
+---
 
-After the server starts successfully, you will see output similar to:
+## OpenCode Integration
 
-```
-[BRIDGE-SERVER] [INFO] Starting Gemini CLI Bridge (MCP + OPENAI)...
-[BRIDGE-SERVER] [INFO] Server running {
-  port: 8765,
-  host: '127.0.0.1',
-  mcpUrl: 'http://127.0.0.1:8765/mcp',
-  openAIUrl: 'http://127.0.0.1:8765/v1'
-}
-```
-
-### 2. Build from Source (Developers)
-
-```bash
-git clone https://github.com/Intelligent-Internet/gemini-cli-common-bridge.git
-cd gemini-cli-common-bridge
-npm install
-npm run build
-npm run start
-```
-
-## Authentication
-
-This bridge server **does not manage its own authentication credentials**. It shares the exact same authentication mechanism as the main `gemini-cli` tool to ensure seamless and secure operation.
-
-- **Cached Credentials**: If you have already logged in through `gemini-cli`'s interactive flow, the bridge server will automatically use the cached credentials.
-- **Environment Variables**: The server will automatically look for and use environment variables such as `GEMINI_API_KEY` or `GOOGLE_APPLICATION_CREDENTIALS`.
-
-As long as your `gemini-cli` is configured and working properly, this bridge server will automatically gain authorization.
-
-## 🛡️ Security Model & Configuration
-
-One of the core designs of `gemini-cli-bridge` is to provide a basic but essential security model to protect your local environment from accidental or malicious operations. Security is crucial when connecting powerful AI models with local tools (such as file system access and shell commands).
-
-**By default, the server runs in the most secure `read-only` mode.**
-
-### Security Modes
-
-You can set the server's security level through the `--mode` command-line argument or by configuring `securityPolicy.mode` in the `settings.json` file. Command-line arguments take precedence.
-
-Four modes are available:
-
-#### 1. `read-only` (Read-Only Mode - **Default**)
-
-This is the most secure and default mode. If you don't make any security configuration, the server will run in this mode.
-
-- ✅ **Allowed**: Only built-in tools that do not modify the local file system or execute arbitrary code. Examples: `read_file`, `list_directory`, `glob`, `google_web_search`, `web_fetch`.
-- ❌ **Forbidden**: All tools with write permissions (such as `write_file`, `replace`), `run_shell_command`, and all tools from external MCP proxies.
-
-**Use Case**: When you only need the AI model to read local files, gather information, or perform web searches, this is the ideal choice.
-
-#### 2. `edit` (Edit Mode)
-
-This mode is designed for local code generation and file editing tasks, providing a balance between functionality and security.
-
-- ✅ **Allowed**: All built-in read-only tools, plus tools with file writing and modification permissions, such as `write_file` and `replace`.
-- ❌ **Forbidden**: `run_shell_command` (prevents executing arbitrary commands) and all external MCP proxy tools (prevents accidental network interactions).
-
-**Use Case**: For use in trusted local development environments for development tasks such as code refactoring and generating new files.
-
-#### 3. `configured` (Configured Mode)
-
-This mode gives you complete control over security through your `settings.json` file. Its behavior is entirely defined by your `securityPolicy` configuration block.
-
-- **Behavior**:
-  - **Tools**: Only tools explicitly listed in the `allowedTools` array will be enabled.
-  - **Shell Commands**: If `run_shell_command` is in `allowedTools`, its executable commands will be strictly limited by the `allow` and `deny` lists in `shellCommandPolicy`.
-  - **MCP Proxy**: By default, all MCP proxy tools are disabled. You must use the `--allow-mcp-proxy` command-line argument to explicitly enable them.
-
-**Use Case**: For advanced users or scenarios requiring fine-grained permission management of specific tools and commands in controlled environments.
-
-#### 4. `yolo` (YOLO Mode - **Highly Dangerous**)
-
-This mode disables almost all built-in security guardrails.
-
-- ✅ **Allowed**: All **built-in** tools, including `run_shell_command` without any restrictions.
-- **MCP Proxy**: Disabled by default, but can be enabled with the `--allow-mcp-proxy` parameter.
-
-> **⚠️ Extreme Danger Warning**: `yolo` mode gives the AI model the ability to execute any command on your system, including destructive operations like `rm -rf /`. **Never** use this mode in production environments or any untrusted network environments.
-
-### External Tool Security (MCP Proxy)
-
-`bridge-server` can connect to external MCP (Model-Context Protocol) servers, known as "MCP proxies," which can provide additional tools (e.g., connecting to internal Jira, operating GitHub, or generating images).
-
-- **Disabled by Default**: For security, all MCP proxy tools are **completely disabled** in `read-only` and `edit` modes.
-- **Explicit Enablement**: You can only enable all discovered MCP proxy tools in `configured` or `yolo` modes by adding the `--allow-mcp-proxy` command-line argument.
-
-> **🔴 MCP Proxy Warning**: Enabling MCP proxy means `bridge-server` will allow the AI model to communicate with third-party services through these proxies. Please ensure you completely trust the source of each configured MCP server and the tools they provide.
-
-### Mandatory Safety Confirmation
-
-To prevent accidental enablement of high-risk modes, `bridge-server` has built-in mandatory interactive confirmation mechanisms.
-
-- **Trigger Conditions**:
-  1. Starting in `yolo` mode.
-  2. Using the `--allow-mcp-proxy` parameter at startup.
-- **Confirmation Process**: The server will pause at startup and require you to type `YES` (all uppercase) in the console and press Enter. If the input doesn't match, the server will safely exit.
-- **Skip Confirmation**: In fully automated scripts or when you fully understand the risks, you can use the `--i-know-what-i-am-doing` command-line argument to skip this interactive confirmation.
-
-### File Operation Scope
-
-All built-in file system tools (such as `read_file`, `write_file`, `list_directory`, etc.) are strictly restricted to operate within **one** directory.
-
-- **Default Scope**: By default, this operation scope is the **current working directory where you start `bridge-server`**.
-- **Custom Scope**: You can explicitly specify the operation scope using the `--target-dir /path/to/your/project` command-line argument.
-
-This mechanism effectively prevents the AI agent from accidentally reading or modifying any files outside your project directory.
-
-### Listen Host
-
-The server defaults to listening on `127.0.0.1`. You can modify this setting through the `--host` command-line argument or the `GEMINI_MCP_HOST` environment variable.
-
-If you want the server to listen on all network interfaces, you can set it to `0.0.0.0`. (Do not use this setting in production environments unless you have additional network security measures or are running in a container network)
-
-Note: In production environments, it is **strongly recommended** to use firewalls or other network security measures to restrict access to this port. **This service does not provide any authentication, authorization, or auditing features**.
-
-## Full Configuration
-
-You can configure the server's behavior through configuration files, command-line arguments, and environment variables.
-
-### Command-Line Arguments & Environment Variables
-
-Arguments take precedence over environment variables and configuration files.
-
-| Parameter | Alias | Environment Variable | Default | Description |
-| :--- | :--- | :--- | :--- | :--- |
-| `--host` | `-h` | - | `127.0.0.1` | Host address for the server to listen on. Use `0.0.0.0` to listen on all network interfaces. |
-| `--port` | `-p` | `GEMINI_MCP_PORT` | `8765` | Port for the server to listen on. |
-| `--tools-model` | - | `GEMINI_TOOLS_DEFAULT_MODEL` | `gemini-2.5-flash` | Default model for tool execution. |
-| `--use-internal-prompt` | - | - | `false` | If set, loads the `GEMINI.md` file and default system prompts as context. (Client-provided system prompts will be treated as the first user prompt) |
-| `--debug` | - | - | `false` | Enable verbose debug logging. |
-| `--mode` | - | - | `read-only` | Set the server's security mode. Options: `read-only`, `edit`, `configured`, `yolo`. |
-| `--allow-mcp-proxy` | - | - | `false` | Enable MCP proxy tools in `configured` or `yolo` modes. |
-| `--i-know-what-i-am-doing` | - | - | `false` | Skip safety confirmation for high-risk modes. Use only when you fully understand the risks. |
-| `--target-dir` | - | - | Current working directory | Set the root directory for file operations. |
-| `--help` | `?` | - | - | Show help information. |
-
-### Configuration File (`.gemini/settings.json`)
-
-**Security Policy (`securityPolicy`)** is the most important configuration item. You can configure it in the user directory (`~/.gemini/settings.json`) or workspace directory (`.gemini/settings.json`).
-
-When mode is `configured`, the server will strictly follow this configuration; command-line arguments will override the `mode` in this setting.
+Add this provider to `~/.config/opencode/opencode.json`:
 
 ```json
-// .gemini/settings.json example
 {
-  "securityPolicy": {
-    "mode": "configured",
-    "allowedTools": [
-      "read_file",
-      "list_directory",
-      "google_web_search",
-      "run_shell_command"
-    ],
-    "shellCommandPolicy": {
-      "allow": ["ls -l", "git status", "npm run test"],
-      "deny": ["rm", "sudo", "docker"]
-    }
-  },
-  "mcpServers": {
-    "github": {
-      "command": "docker",
-      "args": ["run", "-i", "--rm", "-e", "GITHUB_PERSONAL_ACCESS_TOKEN=${GITHUB_PAT}", "ghcr.io/github/github-mcp-server"],
-      "trust": true
+  "provider": {
+    "gemini-bridge": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Gemini CLI Bridge",
+      "options": {
+        "baseURL": "http://127.0.0.1:9000/v1"
+      },
+      "models": {
+        "gemini-3.1-pro-preview": { "name": "Gemini 3.1 Pro" },
+        "gemini-3.1-flash-lite": { "name": "Gemini 3.1 Flash Lite" },
+        "gemini-3-pro-preview": { "name": "Gemini 3 Pro" },
+        "gemini-3-flash-preview": { "name": "Gemini 3 Flash" },
+        "gemini-2.5-pro": { "name": "Gemini 2.5 Pro" },
+        "gemini-2.5-flash": { "name": "Gemini 2.5 Flash" }
+      }
     }
   }
 }
 ```
 
-- **`securityPolicy`**: Controls the server's security boundaries. **If this item is missing and no explicit command-line arguments are set, the server will default to the most secure `read-only` mode**.
-  - **`mode`**:
-    - `"read-only"` (default): Only allows execution of read-only tools (such as `read_file`, `list_directory`).
-    - `"edit"`: Allows file editing tools but forbids `run_shell_command`.
-    - `"configured"`: Recommended mode. Only allows tools explicitly listed in the `allowedTools` array.
-    - `"yolo"`: Most insecure mode. Allows all tools without any restrictions.
-  - **`allowedTools`**: In `configured` mode, defines which tools (including those from external MCP servers) can be registered and called.
-  - **`shellCommandPolicy`**: Provides fine-grained control over the `run_shell_command` tool. `deny` rules take precedence over `allow` rules.
-
-- **`mcpServers`**: Configures external MCP servers to extend the bridge's tool capabilities.
-
-- Other configuration items can refer to the [Gemini CLI Configuration Documentation](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/configuration.md).
-
-### `settings.json` Configuration Support in `bridge-server`
-
-| Configuration Item | Support Status | Reason & Description |
-| :--- | :--- | :--- |
-| **`securityPolicy`** | ✅ **Fully Supported** | **Core feature**. This is the main security mechanism added by `bridge-server` to control tool access permissions and command execution. |
-| **`coreTools`** | ✅ **Fully Supported** | Directly affects which built-in tools are registered during `ToolRegistry` initialization, controlling the tool set exposed through MCP. |
-| **`excludeTools`** | ✅ **Fully Supported** | Similar to `coreTools`, used to remove specific tools from the available tool set, part of the security policy. |
-| **`toolDiscoveryCommand`** | ✅ **Fully Supported** | The server will execute this command to discover custom tools and expose them through the MCP protocol. |
-| **`toolCallCommand`** | ✅ **Fully Supported** | When calling a discovered custom tool through MCP, the server will execute this command. |
-| **`mcpServers`** | ✅ **Fully Supported** | The server will attempt to connect and integrate all external tool servers configured in `mcpServers`. |
-| **`selectedAuthType`** | ✅ **Fully Supported** | **Key configuration**. Determines how `bridge-server` authenticates with Google APIs. |
-| **`fileFiltering`** | ✅ **Fully Supported** | File tools used internally by `bridge-server` (such as `glob`) will follow rules like `respectGitIgnore` in this configuration. |
-| **`telemetry`** | ✅ **Fully Supported** | The server will initialize and configure OpenTelemetry based on these settings for telemetry data collection. |
-| **`usageStatisticsEnabled`** | ✅ **Fully Supported** | Controls whether to send anonymous usage statistics to Google. |
-| **`contextFileName`** | 🟡 **Conditional Support** | Only effective when `bridge-server` is started with the `--use-internal-prompt` argument. |
-| **`theme`** | ❌ **Not Supported** | `bridge-server` is a UI-less backend service with no visual themes. |
-| **`autoAccept`** | ❌ **Not Relevant** | `bridge-server` is internally hard-coded to `YOLO` approval mode and never waits for interactive user confirmation. Its security is ensured by `securityPolicy`. |
-| **`sandbox`** | ❌ **Not Supported** | `bridge-server` **does not create** sandboxes. It can only detect if it's already running in a sandbox created by other processes (such as `gemini-cli`). |
-| **`checkpointing`** | ❌ **Not Supported** | This feature is tightly coupled with `gemini-cli`'s interactive sessions and local Git snapshots, not applicable to stateless servers. |
-| **`preferredEditor`** | ❌ **Not Supported** | Used to open external editors in `gemini-cli`, `bridge-server` has no such interaction flow. |
-| **`bugCommand`** | ❌ **Not Supported** | This is configuration for `gemini-cli`'s `/bug` command, unrelated to `bridge-server`. |
-| **`hideTips`** | ❌ **Not Supported** | Pure UI configuration. |
-| **`hideWindowTitle`** | ❌ **Not Supported** | Pure UI configuration. |
-| **`accessibility`** | ❌ **Not Supported** | Pure UI configuration, used to disable loading animations, etc. |
-
-## API Endpoints
-
-### MCP Endpoint
-
-- **URL**: `http://localhost:8765/mcp`
-- **Protocol**: Model Context Protocol (MCP)
-- **Usage**: Connect MCP-compatible clients to access all configured tools
-
-### OpenAI Compatible Endpoints
-
-#### Chat Completions
-- **URL**: `http://localhost:8765/v1/chat/completions`
-- **Method**: POST
-- **Compatibility**: Full OpenAI Chat Completions API compatibility
-- **Features**: Supports streaming and non-streaming responses, function calling
-
-#### Models
-- **URL**: `http://localhost:8765/v1/models`
-- **Method**: GET
-- **Returns**: List of available Gemini models
-
-## Telemetry, Terms of Service & Privacy
-
-This service **does not introduce any new telemetry or data collection mechanisms**. It relies entirely on the OpenTelemetry (OTEL) system built into the `@google/gemini-cli-core` package. All telemetry data (if enabled) will follow the main configuration of `gemini-cli`.
-
-Your usage is subject to the terms of service and privacy policies corresponding to the `gemini-cli` account type you use for authentication.
-
-- [Gemini CLI Telemetry Documentation](https://github.com/google-gemini/gemini-cli/blob/main/docs/telemetry.md)
-- [Gemini CLI Terms of Service and Privacy Statement](https://github.com/google-gemini/gemini-cli/blob/main/docs/tos-privacy.md)
-
-## Example Usage
-
-### Using with Open WebUI
-
-1. Start the bridge server:
-   ```bash
-   gemini-cli-bridge --mode=edit --port=8765
-   ```
-
-2. Configure Open WebUI to use the bridge server:
-   - Base URL: `http://localhost:8765/v1`
-   - API Key: Any value (authentication is handled by gemini-cli)
-
-### Using with MCP Clients
-
-Connect your MCP client to `http://localhost:8765/mcp` to access all configured tools.
-
-### Using with curl
-
 ```bash
-# Chat completion
-curl -X POST http://localhost:8765/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer dummy-key" \
-  -d '{
-    "model": "gemini-2.5-flash",
-    "messages": [
-      {"role": "user", "content": "Hello, how are you?"}
-    ]
-  }'
+# Start bridge
+GEMINI_MCP_PORT=9000 gemini-cli-bridge --mode edit
 
-# List models
-curl http://localhost:8765/v1/models
+# OpenCode sees the models automatically
+opencode models gemini-bridge
 ```
 
-## Troubleshooting
+---
 
-### Common Issues
-
-1. **Authentication Errors**: Ensure `gemini-cli` is properly authenticated first
-2. **Port Already in Use**: Change the port using `--port` argument
-3. **Tool Access Denied**: Check your security mode and policy configuration
-
-### Debug Mode
-
-Enable debug logging to troubleshoot issues:
+## Usage
 
 ```bash
+# Start with defaults
+gemini-cli-bridge
+
+# Custom port
+GEMINI_MCP_PORT=9000 gemini-cli-bridge
+
+# Enable file writing
+gemini-cli-bridge --mode edit --target-dir /path/to/project
+
+# Debug logging
 gemini-cli-bridge --debug
 ```
 
-## Contributing
+| Flag | Default | Description |
+|---|---|---|
+| `--port` / `GEMINI_MCP_PORT` | `8765` | Listen port |
+| `--mode` | `read-only` | Security mode: `read-only`, `edit`, `configured`, `yolo` |
+| `--target-dir` | cwd | Root for file operations |
+| `--debug` | `false` | Verbose logging |
 
-This is an active development project, and we welcome community contributions! Please follow these steps:
+### Authentication
 
-1. Fork this repository and make changes in your local environment.
-2. Submit a Pull Request describing your changes and their purpose.
-3. We will review your request promptly and provide feedback.
+No extra auth config needed. The bridge uses the same cached OAuth credentials as the `gemini-cli` tool. If `gemini-cli` can talk to Gemini, so can the bridge.
 
-Thank you for your participation!
+---
+
+## Endpoints
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/v1/chat/completions` | POST | OpenAI-compatible chat (stream + non-stream) |
+| `/v1/models` | GET | List available models |
+| `/mcp` | SSE | MCP protocol endpoint |
+
+---
+
+## Credits
+
+- **Original project:** [@Intelligent-Internet/gemini-cli-mcp-openai-bridge](https://github.com/Intelligent-Internet/gemini-cli-mcp-openai-bridge)
+- **Gemini CLI:** [google-gemini/gemini-cli](https://github.com/google-gemini/gemini-cli)
+- **$ref fix + model switching:** [bulgadev](https://github.com/bulgadev) + [OpenCode](https://opencode.ai)
+
+---
 
 ## License
 
-This project is licensed under the Apache License 2.0. See the [LICENSE](LICENSE) file for details.
-
-## Related Projects
-
-- [Gemini CLI](https://github.com/google-gemini/gemini-cli) - The core command-line AI workflow tool
-- [Model Context Protocol](https://github.com/modelcontextprotocol/specification) - The protocol for connecting AI models to tools
+Apache License 2.0 — see [LICENSE](LICENSE).

--- a/bridge-server/src/bridge/openai.ts
+++ b/bridge-server/src/bridge/openai.ts
@@ -184,6 +184,10 @@ export function createOpenAIRouter(config: Config, debugMode = false): Router {
     res.json({
       object: 'list',
       data: [
+        { id: 'gemini-3.1-pro-preview', object: 'model', owned_by: 'google' },
+        { id: 'gemini-3.1-flash-lite', object: 'model', owned_by: 'google' },
+        { id: 'gemini-3-flash-preview', object: 'model', owned_by: 'google' },
+        { id: 'gemini-3-pro-preview', object: 'model', owned_by: 'google' },
         { id: 'gemini-2.5-pro', object: 'model', owned_by: 'google' },
         { id: 'gemini-2.5-flash', object: 'model', owned_by: 'google' },
       ],

--- a/bridge-server/src/gemini-client.ts
+++ b/bridge-server/src/gemini-client.ts
@@ -22,27 +22,76 @@ import {
 } from './types.js';
 import { logger } from './utils/logger.js';
 
-/**
- * Recursively removes fields from a JSON schema that are not supported by the
- * Gemini API.
- * @param schema The JSON schema to sanitize.
- * @returns A new schema object without the unsupported fields.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const UNSUPPORTED_KEYS = new Set([
+  '$schema', '$ref', 'ref', '$defs', 'definitions',
+  'additionalProperties', 'patternProperties',
+  'exclusiveMinimum', 'exclusiveMaximum',
+  'oneOf', 'anyOf', 'allOf', 'not',
+  'if', 'then', 'else',
+  'dependentSchemas', 'dependentRequired',
+  'unevaluatedProperties', 'unevaluatedItems',
+  'contentEncoding', 'contentMediaType',
+]);
+
+function resolveRef(schema: any, root: any): any {
+  if (typeof schema !== 'object' || schema === null) return schema;
+  const refValue = schema.$ref || schema.ref;
+  if (refValue) {
+    const defs = root.$defs || root.definitions || {};
+    if (typeof refValue === 'string') {
+      let defName: string | null = null;
+      if (refValue.startsWith('#/$defs/')) {
+        defName = refValue.slice('#/$defs/'.length);
+      } else if (refValue.startsWith('#/definitions/')) {
+        defName = refValue.slice('#/definitions/'.length);
+      } else if (defs[refValue]) {
+        defName = refValue;
+      }
+      if (defName && defs[defName]) {
+        const resolved = { ...defs[defName] };
+        for (const k of Object.keys(schema)) {
+          if (k !== '$ref' && k !== 'ref') {
+            (resolved as any)[k] = schema[k];
+          }
+        }
+        return resolveRef(resolved, root);
+      }
+    }
+  }
+  if (Array.isArray(schema)) {
+    return schema.map(item => resolveRef(item, root));
+  }
+  if (typeof schema === 'object') {
+    const result: any = {};
+    for (const key of Object.keys(schema)) {
+      result[key] = resolveRef(schema[key], root);
+    }
+    return result;
+  }
+  return schema;
+}
+
 function sanitizeGeminiSchema(schema: any): any {
   if (typeof schema !== 'object' || schema === null) {
     return schema;
   }
 
-  // Create a new object, filtering out unsupported keys at the current level.
+  const resolved = resolveRef(schema, schema);
+
   const newSchema: { [key: string]: any } = {};
-  for (const key in schema) {
-    if (key !== '$schema' && key !== 'additionalProperties') {
-      newSchema[key] = schema[key];
+  for (const key in resolved) {
+    if (!UNSUPPORTED_KEYS.has(key)) {
+      newSchema[key] = resolved[key];
     }
   }
 
-  // Recurse into nested 'properties' and 'items'.
+  if (resolved.exclusiveMinimum !== undefined && newSchema.minimum === undefined) {
+    newSchema.minimum = resolved.exclusiveMinimum;
+  }
+  if (resolved.exclusiveMaximum !== undefined && newSchema.maximum === undefined) {
+    newSchema.maximum = resolved.exclusiveMaximum;
+  }
+
   if (newSchema.properties) {
     const newProperties: { [key: string]: any } = {};
     for (const key in newSchema.properties) {
@@ -267,6 +316,11 @@ export class GeminiApiClient {
 
     if (!lastMessage) {
       throw new Error('No message to send.');
+    }
+
+    // Set the requested model before creating the chat session
+    if (model && typeof model === 'string') {
+      try { this.config.setModel(model); } catch (e) { logger.warn('Failed to set model:', e); }
     }
 
     // Create a new, isolated chat session for each request.

--- a/dist/bridge/openai.js
+++ b/dist/bridge/openai.js
@@ -1,0 +1,169 @@
+import { Router } from 'express';
+import { createOpenAIStreamTransformer } from './stream-transformer.js';
+import { GeminiApiClient } from '../gemini-client.js';
+import { mapErrorToOpenAIError } from '../utils/error-mapper.js';
+import { logger } from '../utils/logger.js';
+import { randomUUID } from 'node:crypto';
+export function createOpenAIRouter(config, debugMode = false) {
+    const router = Router();
+    // Middleware: Add a requestId to each request.
+    router.use((req, res, next) => {
+        req.requestId = randomUUID();
+        next();
+    });
+    router.post('/chat/completions', async (req, res) => {
+        const requestId = req.requestId;
+        const startTime = Date.now();
+        try {
+            const body = req.body;
+            logger.info('OpenAI bridge request received', {
+                requestId,
+                model: body.model,
+                stream: body.stream,
+            });
+            logger.debug(debugMode, 'Request body:', { requestId, body });
+            const stream = body.stream !== false;
+            const client = new GeminiApiClient(config, debugMode);
+            const geminiStream = await client.sendMessageStream({
+                model: body.model,
+                messages: body.messages,
+                tools: body.tools,
+                tool_choice: body.tool_choice,
+            });
+            if (stream) {
+                // --- Streaming Response ---
+                res.setHeader('Content-Type', 'text/event-stream');
+                res.setHeader('Cache-Control', 'no-cache');
+                res.setHeader('Connection', 'keep-alive');
+                res.flushHeaders();
+                const openAIStream = createOpenAIStreamTransformer(body.model, debugMode);
+                // --- Core streaming logic ---
+                // Create a ReadableStream to wrap our Gemini event stream.
+                const readableStream = new ReadableStream({
+                    async start(controller) {
+                        for await (const value of geminiStream) {
+                            controller.enqueue(value);
+                        }
+                        controller.close();
+                    },
+                });
+                // Pipe our stream through the transformer.
+                const transformedStream = readableStream.pipeThrough(openAIStream);
+                const reader = transformedStream.getReader();
+                // Manually read each transformed chunk and write it to the response immediately.
+                try {
+                    while (true) {
+                        const { done, value } = await reader.read();
+                        if (done) {
+                            break;
+                        }
+                        res.write(value);
+                    }
+                }
+                finally {
+                    reader.releaseLock();
+                }
+                // --- End of core streaming logic ---
+                const durationMs = Date.now() - startTime;
+                logger.info('OpenAI bridge request finished', {
+                    requestId,
+                    status: 'success',
+                    durationMs,
+                });
+                res.end();
+            }
+            else {
+                // --- Non-streaming logic ---
+                let fullTextContent = '';
+                const toolCalls = [];
+                let finishReason = 'stop';
+                // 1. In-server aggregation of all stream chunks
+                for await (const chunk of geminiStream) {
+                    if (chunk.type === 'text' && chunk.data) {
+                        fullTextContent += chunk.data;
+                    }
+                    else if (chunk.type === 'tool_code' && chunk.data) {
+                        const toolCallId = `call_${chunk.data.name}_${randomUUID()}`;
+                        toolCalls.push({
+                            id: toolCallId,
+                            type: 'function',
+                            function: {
+                                name: chunk.data.name,
+                                arguments: JSON.stringify(chunk.data.args),
+                            },
+                        });
+                    }
+                }
+                // 2. Determine finish_reason based on aggregated results
+                if (toolCalls.length > 0) {
+                    finishReason = 'tool_calls';
+                }
+                // 3. Construct the complete OpenAI response object
+                const assistantMessage = {
+                    role: 'assistant',
+                    content: fullTextContent || null, // content is null if only tool calls are present
+                };
+                if (toolCalls.length > 0) {
+                    assistantMessage.tool_calls = toolCalls;
+                }
+                const finalResponse = {
+                    id: `chatcmpl-${randomUUID()}`,
+                    object: 'chat.completion',
+                    created: Math.floor(startTime / 1000),
+                    model: body.model,
+                    choices: [
+                        {
+                            index: 0,
+                            message: assistantMessage,
+                            finish_reason: finishReason,
+                        },
+                    ],
+                    // usage is omitted as it's not available from Gemini streaming response.
+                };
+                const durationMs = Date.now() - startTime;
+                logger.info('OpenAI bridge non-streaming request finished', {
+                    requestId,
+                    status: 'success',
+                    durationMs,
+                });
+                // 4. Send the JSON response
+                res.status(200).json(finalResponse);
+            }
+        }
+        catch (e) {
+            const durationMs = Date.now() - startTime;
+            logger.error('OpenAI bridge request failed', e, {
+                requestId,
+                durationMs,
+            });
+            // 调用新的错误映射函数
+            const { openAIError, statusCode } = mapErrorToOpenAIError(e);
+            if (!res.headersSent) {
+                res.status(statusCode).json(openAIError);
+            }
+            else {
+                // If headers are already sent, we can't change the status code,
+                // but we can send an error in the stream.
+                res.write(`data: ${JSON.stringify({ error: openAIError.error })}\n\n`);
+                res.end();
+            }
+        }
+    });
+    // The /v1/models endpoint can be added here.
+    router.get('/models', (req, res) => {
+        // This can return a fixed list of models or get them from the config.
+        res.json({
+            object: 'list',
+            data: [
+                { id: 'gemini-3.1-pro-preview', object: 'model', owned_by: 'google' },
+                { id: 'gemini-3.1-flash-lite', object: 'model', owned_by: 'google' },
+                { id: 'gemini-3-flash-preview', object: 'model', owned_by: 'google' },
+                { id: 'gemini-3-pro-preview', object: 'model', owned_by: 'google' },
+                { id: 'gemini-2.5-pro', object: 'model', owned_by: 'google' },
+                { id: 'gemini-2.5-flash', object: 'model', owned_by: 'google' },
+            ],
+        });
+    });
+    return router;
+}
+//# sourceMappingURL=openai.js.map

--- a/dist/gemini-client.js
+++ b/dist/gemini-client.js
@@ -1,0 +1,426 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { GeminiChat } from '@google/gemini-cli-core';
+import { FunctionCallingConfigMode, } from '@google/genai';
+import { logger } from './utils/logger.js';
+
+const unsupportedKeys = [
+    '$schema',
+    '$ref',
+    'ref',
+    '$defs',
+    'definitions',
+    'additionalProperties',
+    'patternProperties',
+    'exclusiveMinimum',
+    'exclusiveMaximum',
+    'oneOf',
+    'anyOf',
+    'allOf',
+    'not',
+    'if',
+    'then',
+    'else',
+    'dependentSchemas',
+    'dependentRequired',
+    'unevaluatedProperties',
+    'unevaluatedItems',
+    'contentEncoding',
+    'contentMediaType',
+];
+
+function resolveRef(schema, root) {
+    if (typeof schema !== 'object' || schema === null) return schema;
+    const refValue = schema.$ref || schema.ref;
+    if (refValue) {
+        const defs = root.$defs || root.definitions || {};
+        if (typeof refValue === 'string') {
+            let defName = null;
+            if (refValue.startsWith('#/$defs/')) {
+                defName = refValue.slice('#/$defs/'.length);
+            } else if (refValue.startsWith('#/definitions/')) {
+                defName = refValue.slice('#/definitions/'.length);
+            } else if (defs[refValue]) {
+                defName = refValue;
+            }
+            if (defName && defs[defName]) {
+                const resolved = { ...defs[defName] };
+                for (const k of Object.keys(schema)) {
+                    if (k !== '$ref' && k !== 'ref') {
+                        resolved[k] = schema[k];
+                    }
+                }
+                return resolveRef(resolved, root);
+            }
+        }
+    }
+    if (Array.isArray(schema)) {
+        return schema.map(item => resolveRef(item, root));
+    }
+    if (typeof schema === 'object') {
+        const result = {};
+        for (const key of Object.keys(schema)) {
+            result[key] = resolveRef(schema[key], root);
+        }
+        return result;
+    }
+    return schema;
+}
+
+function sanitizeGeminiSchema(schema) {
+    if (typeof schema !== 'object' || schema === null) {
+        return schema;
+    }
+
+    const resolved = resolveRef(schema, schema);
+
+    const newSchema = {};
+    for (const key in resolved) {
+        if (!unsupportedKeys.includes(key)) {
+            newSchema[key] = resolved[key];
+        }
+    }
+
+    if (resolved.exclusiveMinimum !== undefined && newSchema.minimum === undefined) {
+        newSchema.minimum = resolved.exclusiveMinimum;
+    }
+    if (resolved.exclusiveMaximum !== undefined && newSchema.maximum === undefined) {
+        newSchema.maximum = resolved.exclusiveMaximum;
+    }
+
+    if (newSchema.properties) {
+        const newProperties = {};
+        for (const key in newSchema.properties) {
+            newProperties[key] = sanitizeGeminiSchema(newSchema.properties[key]);
+        }
+        newSchema.properties = newProperties;
+    }
+
+    if (newSchema.items) {
+        newSchema.items = sanitizeGeminiSchema(newSchema.items);
+    }
+
+    if (newSchema.type === 'object' && newSchema.properties) {
+        for (const val of Object.values(newSchema.properties)) {
+            if (typeof val === 'object' && val !== null) {
+                sanitizeGeminiSchema(val);
+            }
+        }
+    }
+
+    return newSchema;
+}
+
+export class GeminiApiClient {
+    config;
+    contentGenerator;
+    debugMode;
+
+    constructor(config, debugMode = false) {
+        this.config = config;
+        this.contentGenerator = this.config.getGeminiClient().getContentGenerator();
+        this.debugMode = debugMode;
+    }
+
+    /**
+     * Parses the original function name from a tool_call_id.
+     * ID format: "call_{functionName}_{uuid}"
+     */
+    parseFunctionNameFromId(toolCallId) {
+        const parts = toolCallId.split('_');
+        if (parts.length > 2 && parts[0] === 'call') {
+            // Reassemble the function name which might contain underscores.
+            return parts.slice(1, parts.length - 1).join('_');
+        }
+        // Fallback mechanism, not ideal but better than sending a wrong name.
+        return 'unknown_tool_from_id';
+    }
+
+    /**
+     * Converts OpenAI tool definitions to Gemini tool definitions.
+     */
+    convertOpenAIToolsToGemini(openAITools) {
+        if (!openAITools || openAITools.length === 0) {
+            return undefined;
+        }
+
+        const functionDeclarations = openAITools
+            .filter(tool => tool.type === 'function' && tool.function)
+            .map(tool => {
+            const sanitizedParameters = sanitizeGeminiSchema(tool.function.parameters);
+            const serialized = JSON.stringify(sanitizedParameters) || '';
+            if (serialized.includes('$ref') || serialized.includes('$defs') || serialized.includes('"definitions"') || serialized.includes('"ref"')) {
+                console.error('[BRIDGE-BUG] ref/$ref/$defs/definitions survived sanitization for tool:', tool.function.name);
+                console.error('[BRIDGE-BUG] Raw parameters:', JSON.stringify(tool.function.parameters));
+                console.error('[BRIDGE-BUG] Sanitized parameters:', serialized);
+            }
+            return {
+                name: tool.function.name,
+                description: tool.function.description,
+                parameters: sanitizedParameters,
+            };
+        });
+
+        if (functionDeclarations.length === 0) {
+            return undefined;
+        }
+
+        return [{ functionDeclarations }];
+    }
+
+    /**
+     * Converts an OpenAI-formatted message to a Gemini-formatted Content object.
+     */
+    openAIMessageToGemini(msg) {
+        // Handle assistant messages, which can contain both text and tool calls
+        if (msg.role === 'assistant') {
+            const parts = [];
+            // Handle text content. It can be null when tool_calls are present.
+            if (msg.content && typeof msg.content === 'string') {
+                parts.push({ text: msg.content });
+            }
+
+            // Handle tool calls
+            if (msg.tool_calls && Array.isArray(msg.tool_calls)) {
+                for (const toolCall of msg.tool_calls) {
+                    if (toolCall.type === 'function' && toolCall.function) {
+                        try {
+                            // Gemini API's functionCall.args expects an object, not a string.
+                            // OpenAI's arguments is a JSON string, so it needs to be parsed.
+                            const argsObject = JSON.parse(toolCall.function.arguments);
+                            parts.push({
+                                functionCall: {
+                                    name: toolCall.function.name,
+                                    args: argsObject,
+                                },
+                            });
+                        }
+                        catch (e) {
+                            logger.warn('Failed to parse tool call arguments',
+                                { arguments: toolCall.function.arguments }, e);
+                        }
+                    }
+                }
+            }
+
+            return { role: 'model', parts };
+        }
+
+        // Handle tool responses
+        if (msg.role === 'tool') {
+            const functionName = this.parseFunctionNameFromId(msg.tool_call_id || '');
+            let responsePayload;
+
+            try {
+                const parsed = JSON.parse(msg.content);
+                if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+                    responsePayload = parsed;
+                }
+                else {
+                    responsePayload = { output: parsed };
+                }
+            }
+            catch (e) {
+                responsePayload = { output: msg.content };
+            }
+
+            return {
+                role: 'user', // A tool response must be in a 'user' role message for Gemini API history.
+                parts: [
+                    {
+                        functionResponse: {
+                            name: functionName,
+                            response: responsePayload,
+                        },
+                    },
+                ],
+            };
+        }
+
+        // Handle user and system messages
+        const role = 'user'; // system and user roles are mapped to 'user'
+
+        if (typeof msg.content === 'string') {
+            return { role, parts: [{ text: msg.content }] };
+        }
+
+        if (Array.isArray(msg.content)) {
+            const parts = msg.content.reduce((acc, part) => {
+                if (part.type === 'text') {
+                    acc.push({ text: part.text || '' });
+                }
+                else if (part.type === 'image_url' && part.image_url) {
+                    const imageUrl = part.image_url.url;
+                    if (imageUrl.startsWith('data:')) {
+                        const [mimePart, dataPart] = imageUrl.split(',');
+                        const mimeType = mimePart.split(':')[1].split(';')[0];
+                        acc.push({ inlineData: { mimeType, data: dataPart } });
+                    }
+                    else {
+                        acc.push({ fileData: { mimeType: 'image/jpeg', fileUri: imageUrl } });
+                    }
+                }
+                return acc;
+            }, []);
+
+            return { role, parts };
+        }
+
+        return { role, parts: [{ text: '' }] };
+    }
+
+    /**
+     * Converts OpenAI messages to Gemini format, merging consecutive tool responses.
+     * Gemini requires all tool responses for a turn to be in a single Content object.
+     */
+    convertMessagesToGemini(messages) {
+        const result = [];
+        let i = 0;
+
+        while (i < messages.length) {
+            const msg = messages[i];
+
+            // If this is a tool response, collect all consecutive tool responses
+            if (msg.role === 'tool') {
+                const toolResponseParts = [];
+
+                // Collect all consecutive tool messages into one Content
+                while (i < messages.length && messages[i].role === 'tool') {
+                    const toolMsg = messages[i];
+                    const functionName = this.parseFunctionNameFromId(toolMsg.tool_call_id || '');
+                    let responsePayload;
+
+                    try {
+                        const parsed = JSON.parse(toolMsg.content);
+                        if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+                            responsePayload = parsed;
+                        }
+                        else {
+                            responsePayload = { output: parsed };
+                        }
+                    }
+                    catch (e) {
+                        responsePayload = { output: toolMsg.content };
+                    }
+
+                    toolResponseParts.push({
+                        functionResponse: {
+                            name: functionName,
+                            response: responsePayload,
+                        },
+                    });
+                    i++;
+                }
+
+                // Add single Content with all tool responses merged
+                result.push({ role: 'user', parts: toolResponseParts });
+            }
+            else {
+                // Non-tool message, convert normally
+                result.push(this.openAIMessageToGemini(msg));
+                i++;
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Sends a streaming request to the Gemini API.
+     */
+    async sendMessageStream({ model, messages, tools, tool_choice, }) {
+        let clientSystemInstruction = undefined;
+        const useInternalPrompt = !!this.config.getUserMemory(); // Check if there is a prompt from GEMINI.md
+
+        // If not using the internal prompt, treat the client's system prompt as the system instruction.
+        if (!useInternalPrompt) {
+            const systemMessageIndex = messages.findIndex(msg => msg.role === 'system');
+            if (systemMessageIndex !== -1) {
+                // Splice returns an array of removed items, so we take the first one.
+                const systemMessage = messages.splice(systemMessageIndex, 1)[0];
+                clientSystemInstruction = this.openAIMessageToGemini(systemMessage);
+            }
+        }
+
+        // Use convertMessagesToGemini to properly merge consecutive tool responses
+        const history = this.convertMessagesToGemini(messages);
+        const lastMessage = history.pop();
+
+        logger.info('Calling Gemini API', { model });
+
+        logger.debug(this.debugMode, 'Sending request to Gemini', {
+            historyLength: history.length,
+            lastMessage,
+        });
+
+        if (!lastMessage) {
+            throw new Error('No message to send.');
+        }
+
+        // Set the requested model before creating the chat session
+        if (model && typeof model === 'string') {
+            try { this.config.setModel(model); } catch (e) { logger.warn('Failed to set model:', e); }
+        }
+
+        // Create a new, isolated chat session for each request.
+        const oneShotChat = new GeminiChat(this.config, this.contentGenerator, {}, history);
+
+        const geminiTools = this.convertOpenAIToolsToGemini(tools);
+
+        const generationConfig = {};
+        // If a system prompt was extracted from the client's request, use it. This
+        // will override any system prompt set in the GeminiChat instance.
+        if (clientSystemInstruction) {
+            generationConfig.systemInstruction = clientSystemInstruction;
+        }
+
+        if (tool_choice && tool_choice !== 'auto') {
+            generationConfig.toolConfig = {
+                functionCallingConfig: {
+                    mode: tool_choice.type === 'function'
+                        ? FunctionCallingConfigMode.ANY
+                        : FunctionCallingConfigMode.AUTO,
+                    allowedFunctionNames: tool_choice.function
+                        ? [tool_choice.function.name]
+                        : undefined,
+                },
+            };
+        }
+
+        const prompt_id = Math.random().toString(16).slice(2);
+        const geminiStream = await oneShotChat.sendMessageStream({
+            message: lastMessage.parts || [],
+            config: {
+                tools: geminiTools,
+                ...generationConfig,
+            },
+        }, prompt_id);
+
+        logger.debug(this.debugMode, 'Got stream from Gemini.');
+
+        // Transform the event stream to a simpler StreamChunk stream
+        return (async function* () {
+            for await (const response of geminiStream) {
+                const parts = response.candidates?.[0]?.content?.parts || [];
+                for (const part of parts) {
+                    if (part.text) {
+                        yield { type: 'text', data: part.text };
+                    }
+                    if (part.functionCall && part.functionCall.name) {
+                        yield {
+                            type: 'tool_code',
+                            data: {
+                                name: part.functionCall.name,
+                                args: part.functionCall.args ?? {},
+                            },
+                        };
+                    }
+                }
+            }
+        })();
+    }
+}
+//# sourceMappingURL=gemini-client.js.map


### PR DESCRIPTION
sanitizeGeminiSchema() only stripped $ref but left $defs/definitions intact, and never resolved $ref references inline. This caused the Gemini CodeAssist API to reject tool schemas with: 'Schema.ref was set alongside unsupported fields'.

Added resolveRef() to inline $ref/ref references from $defs/definitions before sanitization. Added ref, $defs, definitions to unsupported keys. Also handles exclusiveMinimum/exclusiveMaximum conversion.